### PR TITLE
docs: fix Node.js example to await res.text() in README

### DIFF
--- a/functions/markdown2html/README.md
+++ b/functions/markdown2html/README.md
@@ -25,7 +25,7 @@ const res = await fetch(api, {
   body: markdownContent,
 })
 
-const htmlString = res.text()
+const htmlString = await res.text()
 
 console.log(htmlString)
 ```


### PR DESCRIPTION
Fixes the Node.js usage example in the README to correctly await `res.text()`, so that the output is the actual HTML string instead of `Promise { <pending> }`.